### PR TITLE
Remove update_footer

### DIFF
--- a/src/Module/RemoveUpdateNotices.php
+++ b/src/Module/RemoveUpdateNotices.php
@@ -49,6 +49,7 @@ class RemoveUpdateNotices extends Instance
         add_filter('pre_site_transient_update_themes', [$this, 'removeUpdateNotices']);
         add_action('admin_init', [$this, 'removeUpdatePage']);
         add_action('admin_menu', [$this, 'removeUpdateNag']);
+        remove_filter( 'update_footer', 'core_update_footer' );
     }
 
     public function removeUpdateNotices()


### PR DESCRIPTION
Removes the version and the update message from the admin footer.

Resolves issue #3