### PR TITLE
Module/RemoveHowdy: make RemoveHowdy i18n compatible

### DIFF
--- a/src/Module/RemoveHowdy.php
+++ b/src/Module/RemoveHowdy.php
@@ -49,7 +49,8 @@ class RemoveHowdy extends Instance
     {
         global $wp_admin_bar;
         $this->account = $wp_admin_bar->get_node('my-account');
-        $this->title = str_replace('Howdy,', $this->replace, $this->account->title);
+        $howdy = str_replace(' %s', '', __('Howdy, %s'));
+        $this->title = str_replace($howdy, $this->replace, $this->account->title);
         $wp_admin_bar->add_node([
             'id' => 'my-account',
             'title' => $this->title


### PR DESCRIPTION
Currently, RemoveHowdy module only works for english language.

This PR changes the hardcoded `'Howdy,'` to `str_replace(' %s', '', __('Howdy, %s'))`, in order to have it replaced, regardless of the current language.

- Tested with both english and french languages
- Project's coding standards checked on the changed file

Bests regards,
Pierre