### PR TITLE
fixed site crash when get_current_screen() returns null

### DIFF
--- a/src/Module/RemoveHelpTabs.php
+++ b/src/Module/RemoveHelpTabs.php
@@ -36,6 +36,9 @@ class RemoveHelpTabs extends Instance
     public function removeHelpTabs()
     {
         $this->screen = get_current_screen();
-        $this->screen->remove_help_tabs();
+
+        if($this->screen) {
+          $this->screen->remove_help_tabs();
+        }
     }
 }


### PR DESCRIPTION
Came across this error when using the `wp_iframe()`-function in a plugin.
As wp_iframe triggers the "`admin_head`"-action, but there will be no current screen, `get_current_screen` will return `null`. Therefore the site will crash when `remove_help_tags` is called.