### PR TITLE
Add "disable-attachment-pages" module

### DIFF
--- a/.github/disable-attachment-pages.md
+++ b/.github/disable-attachment-pages.md
@@ -1,0 +1,13 @@
+# disable-attachment-pages
+
+### Description
+Disable attachment pages.
+
+### Usage
+Supports single instance.
+```php
+intervention('disable-attachment-pages');
+```
+
+### Credit
+https://gschoppe.com/wordpress/disable-attachment-pages/

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ intervention('remove-menu-items', ['themes', 'plugins'], ['editor', 'author']);
 * [add-dashboard-redirect](.github/add-dashboard-redirect.md)
 * [add-menu-page](.github/add-menu-page.md)
 * [add-svg-support](.github/add-svg-support.md)
+* [disable-attachment-pages](.github/disable-attachment-pages.md)
 * [remove-customizer-items](.github/remove-customizer-items.md)
 * [remove-dashboard-items](.github/remove-dashboard-items.md)
 * [remove-emoji](.github/remove-emoji.md)
@@ -104,6 +105,9 @@ intervention('remove-menu-items', ['themes', 'plugins'], ['editor', 'author']);
 
 * **add-svg-support**<br>
 `intervention('add-svg-support', $roles(string|array));`
+
+* **disable-attachment-pages**<br>
+`intervention('disable-attachment-pages');
 
 * **remove-customizer-items**<br>
 `intervention('remove-customizer-items', $items(string|array), $roles(string|array));`

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ intervention('remove-menu-items', ['themes', 'plugins'], ['editor', 'author']);
 `intervention('add-svg-support', $roles(string|array));`
 
 * **disable-attachment-pages**<br>
-`intervention('disable-attachment-pages');
+`intervention('disable-attachment-pages');`
 
 * **remove-customizer-items**<br>
 `intervention('remove-customizer-items', $items(string|array), $roles(string|array));`

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "soberwp/intervention",
+  "name": "runofthemill/intervention",
   "type": "wordpress-plugin",
   "license": "MIT",
   "description": "WordPress plugin containing modules to cleanup and customize wp-admin.",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "runofthemill/intervention",
+  "name": "soberwp/intervention",
   "type": "wordpress-plugin",
   "license": "MIT",
   "description": "WordPress plugin containing modules to cleanup and customize wp-admin.",

--- a/src/Module/DisableAttachmentPages.php
+++ b/src/Module/DisableAttachmentPages.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Sober\Intervention\Module;
+
+use Sober\Intervention\Instance;
+
+/**
+ * Module: disable-attachment-pages
+ *
+ * Completely disable attachment pages the right way. No forced redirects or 404s, no reserved slugs.
+ *
+ * @example intervention('disable-attachment-pages');
+ *
+ * @link https://gschoppe.com/wordpress/disable-attachment-pages/
+ *
+ * @package    WordPress
+ * @subpackage Intervention
+ * @since      1.2.0
+ */
+class DisableAttachmentPages extends Instance
+{
+    public function run()
+    {
+        $this->hook();
+    }
+
+    protected function hook()
+    {
+        $this->disableAttachmentPages();
+        register_activation_hook(__FILE__, 'flush_rewrite_rules');
+        register_deactivation_hook(__FILE__, 'flush_rewrite_rules');
+    }
+
+    public function disableAttachmentPages()
+    {
+        add_filter('rewrite_rules_array', [$this, 'removeAttachmentRewrites']);
+        add_filter('wp_unique_post_slug', [$this, 'wpUniquePostSlug'], 10, 6);
+        add_filter('request', [$this, 'removeAttachmentQueryVar']);
+        add_filter('attachment_link', [$this, 'changeAttachmentLinkToFile'], 10, 2);
+        // just in case everything else fails, and somehow an attachment page is requested
+        add_action('template_redirect', [$this, 'redirectAttachmentPagesToFile']);
+    }
+    
+    public function removeAttachmentRewrites($rules)
+    {
+        foreach ($rules as $pattern => $rewrite) {
+            if (preg_match('/([\?&]attachment=\$matches\[)/', $rewrite)) {
+                unset($rules[$pattern]);
+            }
+        }
+            return $rules;
+    }
+ 
+    // this function is a trimmed down version of `wp_unique_post_slug` from WordPress 4.8.3
+    public function wpUniquePostSlug($slug, $post_ID, $post_status, $post_type, $post_parent, $original_slug)
+    {
+            global $wpdb, $wp_rewrite;
+ 
+        if ($post_type =='nav_menu_item') {
+            return $slug;
+        }
+ 
+        if ($post_type == "attachment") {
+            $prefix = apply_filters('gjs_attachment_slug_prefix', 'wp-attachment-', $original_slug, $post_ID, $post_status, $post_type, $post_parent);
+            if (! $prefix) {
+                return $slug;
+            }
+            // remove this filter and rerun with the prefix
+            remove_filter('wpUniquePostSlug', [$this, 'wpUniquePostSlug'], 10);
+            $slug = wpUniquePostSlug($prefix . $original_slug, $post_ID, $post_status, $post_type, $post_parent);
+            add_filter('wpUniquePostSlug', [$this, 'wpUniquePostSlug'], 10, 6);
+
+            return $slug;
+        }
+ 
+        if (! is_post_type_hierarchical($post_type)) {
+            return $slug;
+        }
+ 
+            $feeds = $wp_rewrite->feeds;
+        if (! is_array($feeds)) {
+            $feeds = array();
+        }
+ 
+        /*
+         * NOTE: This is the big change. We are NOT checking attachments along with our post type
+         */
+        $slug = $original_slug;
+        $check_sql = "SELECT post_name FROM $wpdb->posts WHERE post_name = %s AND post_type IN ( %s ) AND ID != %d AND post_parent = %d LIMIT 1";
+        $post_name_check = $wpdb->get_var($wpdb->prepare($check_sql, $slug, $post_type, $post_ID, $post_parent));
+
+        /**
+         * Filters whether the post slug would make a bad hierarchical post slug.
+         *
+         * @since 3.1.0
+         *
+         * @param bool   $bad_slug    Whether the post slug would be bad in a hierarchical post context.
+         * @param string $slug        The post slug.
+         * @param string $post_type   Post type.
+         * @param int    $post_parent Post parent ID.
+         */
+        if ($post_name_check || in_array($slug, $feeds) || 'embed' === $slug || preg_match("@^($wp_rewrite->pagination_base)?\d+$@", $slug)  || apply_filters('wp_unique_post_slug_is_bad_hierarchical_slug', false, $slug, $post_type, $post_parent)) {
+            $suffix = 2;
+            do {
+                $alt_post_name = _truncate_post_slug($slug, 200 - ( strlen($suffix) + 1 )) . "-$suffix";
+                $post_name_check = $wpdb->get_var($wpdb->prepare($check_sql, $alt_post_name, $post_type, $post_ID, $post_parent));
+                $suffix++;
+            } while ($post_name_check);
+            $slug = $alt_post_name;
+        }
+ 
+            return $slug;
+    }
+ 
+    public function removeAttachmentQueryVar($vars)
+    {
+        if (! empty($vars['attachment'])) {
+            $vars['page'] = '';
+            $vars['name'] = $vars['attachment'];
+            unset($vars['attachment']);
+        }
+ 
+            return $vars;
+    }
+ 
+    public function makeAttachmentsPrivate($args, $slug)
+    {
+        if ($slug == 'attachment') {
+            $args['public'] = false;
+            $args['publicly_queryable'] = false;
+        }
+            return $args;
+    }
+ 
+    public function changeAttachmentLinkToFile($url, $id)
+    {
+        $attachment_url = wp_get_attachment_url($id);
+        if ($attachment_url) {
+            return $attachment_url;
+        }
+            return $url;
+    }
+ 
+    public function redirectAttachmentPagesToFile()
+    {
+        if (is_attachment()) {
+            $id = get_the_ID();
+            $url = wp_get_attachment_url($id);
+            if ($url) {
+                wp_redirect($url, 301);
+                die;
+            }
+        }
+    }
+}

--- a/src/Module/DisableAttachmentPages.php
+++ b/src/Module/DisableAttachmentPages.php
@@ -56,22 +56,9 @@ class DisableAttachmentPages extends Instance
     // this function is a trimmed down version of `wp_unique_post_slug` from WordPress 4.8.3
     public function wpUniquePostSlug($slug, $post_ID, $post_status, $post_type, $post_parent, $original_slug)
     {
-            global $wpdb, $wp_rewrite;
+        global $wpdb, $wp_rewrite;
 
         if ($post_type =='nav_menu_item') {
-            return $slug;
-        }
-
-        if ($post_type == "attachment") {
-            $prefix = apply_filters('gjs_attachment_slug_prefix', 'wp-attachment-', $original_slug, $post_ID, $post_status, $post_type, $post_parent);
-            if (! $prefix || 'wp-attachment-' === $prefix) {
-                return $slug;
-            }
-            // remove this filter and rerun with the prefix
-            remove_filter('wpUniquePostSlug', [$this, 'wpUniquePostSlug'], 10);
-            $slug = $this->wpUniquePostSlug($prefix . $original_slug, $post_ID, $post_status, $post_type, $post_parent, $original_slug);
-            add_filter('wpUniquePostSlug', [$this, 'wpUniquePostSlug'], 10, 6);
-
             return $slug;
         }
 
@@ -79,7 +66,7 @@ class DisableAttachmentPages extends Instance
             return $slug;
         }
 
-            $feeds = $wp_rewrite->feeds;
+        $feeds = $wp_rewrite->feeds;
         if (! is_array($feeds)) {
             $feeds = array();
         }


### PR DESCRIPTION
Added code from https://gschoppe.com/wordpress/disable-attachment-pages/ - I tried to match the structure to other modules, but other than making the function names camel case the code is unchanged.

There's a filter available (`gjs_attachment_slug_prefix`) which I'm not sure is worth keeping, and an unused function (`makeAttachmentsPrivate()`) which I asked about and got [this response](https://gschoppe.com/wordpress/disable-attachment-pages/#comment-3174):

> The gjs_attachment_slug_prefix filter is provided so that users can change the default of wp-attachment to another value, in case they need to for some reason. This is important because the slug wp-attachment-«original-file-slug» will still be reserved by WordPress, so it is possible that on some sites this could cause collision issues.
> 
> make_attachments_private(){} was originally hooked to the register_post_type_args filter, as it should cause the attachment post type to not reserve slugs. However, attachments currently ignore the standard post type arguments. I’ve re-added this hook to the to the plugin, in the hope that someday, WordPress may add support these arguments properly.

I haven't done thorough testing, but enabling this module w/ intervention does indeed disable attachment pages, rewrites the URLs, and seems to work as advertised!