### PR TITLE
Change admin_init to admin_menu for removeMenuItems

### DIFF
--- a/src/Module/RemoveMenuItems.php
+++ b/src/Module/RemoveMenuItems.php
@@ -37,7 +37,7 @@ class RemoveMenuItems extends Instance
 
     protected function hook()
     {
-        add_action('admin_init', [$this, 'removeMenuItems']);
+        add_action('admin_menu', [$this, 'removeMenuItems']);
     }
 
     public function removeMenuItems()


### PR DESCRIPTION
Had this issue for a while now and decided to take a second to figure out why it was happening.

`removeMenuItems()` has the tendency to run before `$menu` is actually setup causing a strange behavior of breaking AJAX in wp-admin.

https://stackoverflow.com/questions/9052416/wordpress-function-remove-menu-page-throws-an-error is related.

You can look at this yourself by installing Query Monitor and checking your browser console log.

![Screenshot](https://log1x.com/screenshots/TDPrjlMt.png)