### PR TITLE
Change admin_init to admin_menu for AddDashBoardRedirect; update hook comments for RemoveMenuItems

### DIFF
--- a/src/Module/AddDashboardRedirect.php
+++ b/src/Module/AddDashboardRedirect.php
@@ -15,7 +15,7 @@ use Sober\Intervention\Utils;
  * @link https://developer.wordpress.org/reference/functions/wp_dashboard_setup/
  * @link https://developer.wordpress.org/reference/functions/wp_redirect/
  * @link https://developer.wordpress.org/reference/functions/admin_url/
- * @link https://developer.wordpress.org/reference/hooks/admin_init/
+ * @link https://developer.wordpress.org/reference/hooks/admin_menu/
  * @link https://developer.wordpress.org/reference/functions/remove_menu_page/
  *
  * @package WordPress
@@ -125,7 +125,7 @@ class AddDashboardRedirect extends Instance
     protected function hook()
     {
         add_action('wp_dashboard_setup', [$this, 'redirect']);
-        add_action('admin_init', [$this, 'removeDashboard']);
+        add_action('admin_menu', [$this, 'removeDashboard']);
     }
 
     public function redirect()

--- a/src/Module/RemoveMenuItems.php
+++ b/src/Module/RemoveMenuItems.php
@@ -7,11 +7,11 @@ use Sober\Intervention\Instance;
 /**
  * Module: remove-menu-items
  *
- * Hooks into admin_init to removes menu item/s for user role/s.
+ * Hooks into admin_menu to removes menu item/s for user role/s.
  *
  * @example intervention('remove-menu-items', $items(string|array), $roles(string|array));
  *
- * @link https://developer.wordpress.org/reference/hooks/admin_init/
+ * @link https://developer.wordpress.org/reference/hooks/admin_menu/
  * @link https://developer.wordpress.org/reference/functions/current_user_can/
  * @link https://developer.wordpress.org/reference/functions/remove_menu_page/
  * @link https://developer.wordpress.org/reference/functions/remove_submenu_page/


### PR DESCRIPTION
Expands on https://github.com/soberwp/intervention/pull/25