### PR TITLE
Re-fix ajax warning

### DIFF
--- a/src/Module/RemoveMenuItems.php
+++ b/src/Module/RemoveMenuItems.php
@@ -37,7 +37,9 @@ class RemoveMenuItems extends Instance
 
     protected function hook()
     {
-        add_action('admin_menu', [$this, 'removeMenuItems']);
+        if (!wp_doing_ajax()) {
+            add_action('admin_init', [$this, 'removeMenuItems']);
+        }
     }
 
     public function removeMenuItems()


### PR DESCRIPTION
Re-fix remove-menu-items ajax warning.
'admin_menu' hook don't remove acf items.
Restored 'admin_init' hook and check if is ajax request.