### PR TITLE
Updated setters for Labels for both Post types and Taxonomies and set correct format for taxonomies links, post type supports and add post type taxonomies

### DIFF
--- a/src/Application/Support/Posttypes/Labels.php
+++ b/src/Application/Support/Posttypes/Labels.php
@@ -22,12 +22,14 @@ class Labels
     /**
      * Interface
      *
+     * @param string $one
+     * @param string $many
      * @param string|array $config
      * @return Sober\Intervention\Application\Support\Posttypes\Labels
      */
-    public static function set($config = false)
+    public static function set($one, $many = false, $config = false)
     {
-        return new self($config);
+        return new self($one, $many, $config);
     }
 
     /**

--- a/src/Application/Support/Posttypes/Register.php
+++ b/src/Application/Support/Posttypes/Register.php
@@ -44,6 +44,7 @@ class Register
         $this->config = $config;
         $this->setDefaults();
         $this->setSupports();
+        $this->setTaxonomies();
         $this->register();
     }
 
@@ -67,13 +68,25 @@ class Register
      * @param string $this->config
      */
     public function setSupports()
-    {
+    {   
+
         if ($this->config->has('supports')) {
-            $keys = Arr::collect($this->config->get('supports'))->keys()->toArray();
-            $keys = array_map(function ($value) {
-                return str_replace('_', '-', $value);
-            }, $keys);
-            $this->config->put('supports', $keys);
+            $this->config->put('supports', array_keys($this->config->pull('supports')));
+        }
+    }
+
+    /**
+     * Set Taxonomies
+     *
+     * Transform from [$x => true, $y = true] to [$x, $y]
+     *
+     * @param string $this->config
+     */
+    public function setTaxonomies()
+    {   
+
+        if ($this->config->has('taxonomies')) {
+            $this->config->put('taxonomies', array_keys($this->config->pull('taxonomies')));
         }
     }
 

--- a/src/Application/Support/Taxonomies/Labels.php
+++ b/src/Application/Support/Taxonomies/Labels.php
@@ -22,12 +22,14 @@ class Labels
     /**
      * Interface
      *
+     * @param string $one
+     * @param string $many
      * @param string|array $config
      * @return Sober\Intervention\Application\Support\Taxonomies\Labels
      */
-    public static function set($config = false)
+    public static function set($one, $many = false, $config = false)
     {
-        return new self($config);
+        return new self($one, $many, $config);
     }
 
     /**

--- a/src/Application/Support/Taxonomies/Register.php
+++ b/src/Application/Support/Taxonomies/Register.php
@@ -76,7 +76,7 @@ class Register
     public function setLinks()
     {
         $this->links = $this->config->has('links') ?
-            $this->config->pull('links') :
+            array_keys($this->config->pull('links')) :
             'post';
     }
 


### PR DESCRIPTION
The labels for the CPT weren't properly created and I saw that the set method was being passed a different arguments and did not mirror the construct method.