### PR TITLE
Fix update option value uploads_use_yearmonth_folders

### DIFF
--- a/src/Application/Media/Uploads.php
+++ b/src/Application/Media/Uploads.php
@@ -52,7 +52,7 @@ class Uploads
     public function options()
     {
         if ($this->config->has('media.uploads.organize')) {
-            update_option('uploads_use_yearmonth_folders', $this->config->get('media.uploads.organize'));
+            update_option('uploads_use_yearmonth_folders', (int) $this->config->get('media.uploads.organize')->first());
         }
     }
 


### PR DESCRIPTION
Setting `media.uploads.organize` to `true` or `false` doesn't work. I think the value of value `uploads_use_yearmonth_folders` should be saved as an integer 1 or 0.

https://codex.wordpress.org/Option_Reference#Media