### PR TITLE
Add option to remove Customizer from wpadminbar

### DIFF
--- a/.github/wp-admin/common.adminbar.md
+++ b/.github/wp-admin/common.adminbar.md
@@ -4,7 +4,7 @@ Remove wp-admin adminbar components.
 
 ### Options;
 
-* Parent items remove child items. 
+* Parent items remove child items.
 * For concise documentation, `option.[x, y]` has been abbreviated from `option.x, option.y`.
 
 ```php
@@ -18,6 +18,7 @@ return [
         'common.adminbar.updates',
         'common.adminbar.site',
         'common.adminbar.site.[menu, visit, dashboard, themes, widgets, menus]',
+        'common.adminbar.customize',
         'common.adminbar.comments',
         'common.adminbar.new',
         'common.adminbar.new.[post, page, media, user]',

--- a/src/Admin/Common/Adminbar.php
+++ b/src/Admin/Common/Adminbar.php
@@ -27,6 +27,7 @@ use Sober\Intervention\Support\Str;
  *     'common.adminbar.updates',
  *     'common.adminbar.site',
  *     'common.adminbar.site.[menu, visit, dashboard, themes, widgets, menus]',
+ *     'common.adminbar.customize',
  *     'common.adminbar.comments',
  *     'common.adminbar.new',
  *     'common.adminbar.new.[post, page, media, user]',
@@ -85,7 +86,7 @@ class Adminbar
             add_action('admin_head', function () {
                 echo '
                 <style>
-                    #wpadminbar #wp-admin-bar-my-account a::before, 
+                    #wpadminbar #wp-admin-bar-my-account a::before,
                     #wpadminbar #wp-admin-bar-my-account.with-avatar > a img,
                     #wpadminbar #wp-admin-bar-my-account.without-avatar > a img {display: none}
                 </style>';
@@ -162,6 +163,11 @@ class Adminbar
 
         if ($this->config->has('common.adminbar.site.menus')) {
             $GLOBALS['wp_admin_bar']->remove_node('menus');
+        }
+
+        // Customize
+        if ($this->config->has('common.adminbar.customize')) {
+            $GLOBALS['wp_admin_bar']->remove_node('customize');
         }
 
         // Comments


### PR DESCRIPTION
Add `common.adminbar.customize` to remove Customizer from wpadminbar