### PR TITLE
Fix warning

### DIFF
--- a/src/Admin/Appearance/Widgets.php
+++ b/src/Admin/Appearance/Widgets.php
@@ -165,9 +165,11 @@ class Widgets
             add_filter('use_widgets_block_editor', '__return_false');
         }
 
-        if ($GLOBALS['pagenow'] === 'widgets.php') {
-            BlockEditor::set($this->editor);
-        }
+        add_action('admin_init', function (){
+            if ($GLOBALS['pagenow'] === 'widgets.php') {
+                BlockEditor::set($this->editor);
+            }
+        });
     }
 
     /**

--- a/src/Admin/Appearance/Widgets.php
+++ b/src/Admin/Appearance/Widgets.php
@@ -165,7 +165,7 @@ class Widgets
             add_filter('use_widgets_block_editor', '__return_false');
         }
 
-        add_action('admin_init', function (){
+        add_action('admin_init', function () {
             if ($GLOBALS['pagenow'] === 'widgets.php') {
                 BlockEditor::set($this->editor);
             }


### PR DESCRIPTION
When setting `'discussion' => false` I get this warning:

```
ErrorException (E_WARNING)
Cannot modify header information - headers already sent by (output started at [...]web/app/mu-plugins/intervention/src/Admin/Appearance/Widgets.php:168)
```