### PR TITLE
Fix: join() passing glue string after array is deprecated

### DIFF
--- a/src/Support/Arr.php
+++ b/src/Support/Arr.php
@@ -264,7 +264,7 @@ class Arr
              */
             if (count($key_arr) > 1) {
                 $key_first = array_shift($key_arr);
-                $key_next = join($key_arr, '.');
+                $key_next = implode('.', $key_arr);
                 $carry[$key_first][$key_next] = $v;
             } else {
                 $carry[$k] = $v;


### PR DESCRIPTION
ERROR: join(): Passing glue string after array is deprecated. Swap the parameters