### PR TITLE
Random errors found with Query Monitor

### DIFF
--- a/intervention.php
+++ b/intervention.php
@@ -71,7 +71,7 @@ function getConfigFile()
 
 function getDatabase()
 {
-    $option = get_option('intervention_admin');
+    $option = get_option('intervention_admin', []);
     $read = [];
     foreach ($option as $role => $array) {
         $read['wp-admin.' . $role] = $array;

--- a/src/Support/Arr.php
+++ b/src/Support/Arr.php
@@ -297,7 +297,7 @@ class Arr
              */
             if (count($key_arr) > 1) {
                 $key_first = array_shift($key_arr);
-                $key_next = join($key_arr, '.');
+                $key_next = join('.', $key_arr);
                 $carry[$key_first][$key_next] = $v;
             } else {
                 $carry[$k] = $v;


### PR DESCRIPTION
I checked out the `interface` branch, did not build any assets or dependencies, logged into my site and saw these two minor issues with the Query Monitor plugin.

`Deprecated | join(): Passing glue string after array is deprecated. Swap the parameters | 8 | +wp-content/plugins/intervention/src/Support/Arr.php:300 | Plugin: intervention`

`Warning | Invalid argument supplied for foreach() | 1 | +wp-content/plugins/intervention/intervention.php:76 | Plugin: intervention`